### PR TITLE
Wrap defineProperty in try/catch block

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,10 @@ if (DOM) {
 			let el = document.createElementNS('http://www.w3.org/2000/svg', name);
 			for (let i in el) {
 				if (!(i in div) || PROP_TO_ATTR_MAP.hasOwnProperty(i)) {
-					Object.defineProperty(el, i, contentPropertyDef(i));
+					try {
+						Object.defineProperty(el, i, contentPropertyDef(i));
+					}
+					catch (e) {}
 				}
 			}
 			return el;


### PR DESCRIPTION
As discussed in issue #2.

This wraps the defineProperty call in a try/catch block. Thus preventing the exception from bubbling up to the user.

I think this is useful only while IE11 is still relevant.
