### PR TITLE
Make this module consumable for projects not using webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import { h, Component } from 'preact';
+import preact from 'preact';
+const { h, Component } = preact;
 
 const DOM = typeof document!=='undefined' && !!document.createElement;
 


### PR DESCRIPTION
If I attempt to import this module into my project (which only uses rollup) via the following code:

``` js
import SVG from 'preact-svg';
```

then rollup reports the following error:

```
preact.js does not export Component 
```

Although Webpack permits destructuring in imports from ES5 modules in various formats, Rollup does not. This module is expecting Webpack-like functionality in `src/index.js`:

``` js
import { h, Component } from 'preact';
```

Even though this project uses rollup to build its distributable, it excludes preact in `rollup.config.js`. I can cause the error described above by removing the `external` config in the main config object and `skip: external` in the `nodeResolve` config nested further in.... which means the reason the import works is because rollup is ignoring it. The tests pass because the Karma config includes a webpack config, which then makes the import in the test file work.

tl;dr in order to make this project consumable without webpack, we need to change

``` js
import { h, Component } from 'preact';
```

into 

``` js
import preact from 'preact';
const { h, Component } = preact;
```
